### PR TITLE
CI: drop unused Travis option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:


### PR DESCRIPTION
This PR removes an option from the CI configuration. That option's been marked as changing: https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration